### PR TITLE
move grenade launcher to inside 049 armory

### DIFF
--- a/Items/GrenadeLauncher.cs
+++ b/Items/GrenadeLauncher.cs
@@ -37,7 +37,7 @@ namespace ExtendedItems.Items
                 new()
                 {
                     Chance = 100,
-                    Location = SpawnLocationType.InsideHidChamber,
+                    Location = SpawnLocationType.Inside049Armory,
                 },
              ],
         };


### PR DESCRIPTION
as opposed to the middle of the micro hallway where it was previously