### PR TITLE
Add Tranquilizer DeBuff

### DIFF
--- a/Items/Tranquilizer.cs
+++ b/Items/Tranquilizer.cs
@@ -117,14 +117,40 @@ namespace ExtendedItems.Items
             Ragdoll? ragdoll = null;
             
             if (ev.Target.IsHuman)
-            { ev.Target.CurrentItem = null; ev.Target.Inventory.enabled = false; ev.Target.EnableEffect(EffectType.AmnesiaItems, byte.MaxValue);
+            { 
+                ev.Target.CurrentItem = null; 
+                ev.Target.Inventory.enabled = false; 
+                ev.Target.EnableEffect(EffectType.AmnesiaItems, byte.MaxValue);
             }
             else
-            { if (ev.Target.Role != RoleTypeId.Scp106) { ragdoll = Ragdoll.CreateAndSpawn(ev.Target.Role.Type, ev.Target.DisplayNickname, new CustomReasonDamageHandler("Tranquilized."), ev.Target.Position, ev.Target.Rotation, ev.Target); } if (ev.Target.Role == RoleTypeId.Scp096) { var crybaby = (Scp096Role)ev.Target.Role; if (crybaby.RageState is Scp096RageState.Enraged or Scp096RageState.Distressed) { crybaby.RageManager.ServerEndEnrage(); } }
+            {
+                if (ev.Target.Role != RoleTypeId.Scp106)
+                {
+                    ragdoll = Ragdoll.CreateAndSpawn(ev.Target.Role.Type, ev.Target.DisplayNickname, new CustomReasonDamageHandler("Tranquilized."), ev.Target.Position, ev.Target.Rotation, ev.Target);
+                } 
+                if (ev.Target.Role == RoleTypeId.Scp096) 
+                { 
+                    var crybaby = (Scp096Role)ev.Target.Role;
+                    if (crybaby.RageState is Scp096RageState.Enraged or Scp096RageState.Distressed)
+                    {
+                        crybaby.RageManager.ServerEndEnrage();
+                    } 
+                }
             }
             Timing.CallDelayed(5, () =>
-            { ev.Target.Inventory.enabled = true; ev.Target.IsGodModeEnabled = false; ev.Target.DisableEffect(EffectType.Ensnared); ev.Target.DisableEffect(EffectType.Flashed); ev.Target.DisableEffect(EffectType.Deafened); ev.Target.DisableEffect(EffectType.AmnesiaItems); ev.Target.CurrentItem = item; if (lift != null) ev.Target.Teleport(lift.Position + Vector3.up * 2f); else ev.Target.Teleport(ev.Target.Position + Vector3.up * 2f); ev.Target.Scale = Vector3.one; ragdoll?.Destroy();
+            { 
+                ev.Target.Inventory.enabled = true; 
+                ev.Target.IsGodModeEnabled = false; 
+                ev.Target.DisableEffect(EffectType.Ensnared); 
+                ev.Target.DisableEffect(EffectType.Flashed); 
+                ev.Target.DisableEffect(EffectType.Deafened); 
+                ev.Target.DisableEffect(EffectType.AmnesiaItems); 
+                ev.Target.CurrentItem = item; 
+                if (lift != null) ev.Target.Teleport(lift.Position + Vector3.up * 2f); 
+                else ev.Target.Teleport(ev.Target.Position + Vector3.up * 2f); ev.Target.Scale = Vector3.one; 
+                ragdoll?.Destroy();
             });
+            
             base.OnShot(ev);
         }
 

--- a/Items/Tranquilizer.cs
+++ b/Items/Tranquilizer.cs
@@ -40,7 +40,7 @@ namespace ExtendedItems.Items
         [Description("Resistance to remove from the chance after being shot.")]
         public float Resistance { get; set; } = 0.05f;
 
-        [Description("Whether tranquilizer should not effect those with AHP.")]
+        [Description("Whether tranquilizer should not effect those with Adrenaline.")]
         public bool AdrenalineBuff { get; set; } = true;
         private bool Affected { get; set; } = true;
 

--- a/Items/Tranquilizer.cs
+++ b/Items/Tranquilizer.cs
@@ -40,6 +40,9 @@ namespace ExtendedItems.Items
         [Description("Resistance to remove from the chance after being shot.")]
         public float Resistance { get; set; } = 0.05f;
 
+        [Description("Whether tranquilizer should not effect those with AHP.")]
+        public bool AhpBuff { get; set; } = true;
+
         [YamlIgnore] private readonly Random _rng = new();
         [YamlIgnore] private readonly Dictionary<uint, float> _resistances = [];
         public ItemType[] Inventory { get; set; } = [];
@@ -76,82 +79,52 @@ namespace ExtendedItems.Items
 
             if (ev.Target == null || Plugin.Instance == null) return;
             if (ev.Target.IsTutorial && !Plugin.Instance.Config.EffectiveOnTutorials) return;
-            { 
-                Exiled.API.Features.Items.Item? item = null;
+            
+            if (AhpBuff && ev.Target.ArtificialHealth >= 1) // AHP cancel, buffs anti-cola and blue candy
+            {
+                base.OnShot(ev);
+                return;
+            };
+            
+            Exiled.API.Features.Items.Item? item = null;
                 
-                if((bool)(Plugin.Instance.Config.ReholdItems!))
-                {
-                    item = ev.Target.CurrentItem;
-                }
-                
-                var rand = _rng.NextDouble();
-                _resistances.TryGetValue(ev.Target.NetId, out float tResistance);
-                
-                var effective = ev.Target.IsScp ? rand < ScpChance - tResistance : rand < HumanChance - tResistance;
-                
-                if ((ev.Target.Role == RoleTypeId.Scp173 && !EffectiveOn173) || !effective)
-                {
-                    base.OnShot(ev);
-                    return;
-                }
-
-                var lift = ev.Player.Lift;
-                
-                ev.Target.Scale = Vector3.zero;
-                _resistances[ev.Target.NetId] = tResistance + Resistance;
-                
-                ev.Target.EnableEffect(EffectType.Ensnared, byte.MaxValue);
-                ev.Target.EnableEffect(EffectType.Flashed, byte.MaxValue);
-                ev.Target.EnableEffect(EffectType.Deafened, byte.MaxValue);
-                
-                ev.Target.IsGodModeEnabled = true;
-                Ragdoll? ragdoll = null;
-                
-                if (ev.Target.IsHuman)
-                {
-                    ev.Target.CurrentItem = null;
-                    ev.Target.Inventory.enabled = false;
-
-                    ev.Target.EnableEffect(EffectType.AmnesiaItems, byte.MaxValue);
-                }
-                else
-                {
-                    if (ev.Target.Role != RoleTypeId.Scp106)
-                    {
-                        ragdoll = Ragdoll.CreateAndSpawn(ev.Target.Role.Type, ev.Target.DisplayNickname,
-                        new CustomReasonDamageHandler("Tranquilized."), ev.Target.Position, ev.Target.Rotation, ev.Target);
-                    }
-                    if (ev.Target.Role == RoleTypeId.Scp096)
-                    {
-                        var crybaby = (Scp096Role)ev.Target.Role;
-                        if (crybaby.RageState is Scp096RageState.Enraged or Scp096RageState.Distressed)
-                        {
-                            crybaby.RageManager.ServerEndEnrage();
-                        }
-                    }
-                }
-
-
-                Timing.CallDelayed(5, () =>
-                {
-                    ev.Target.Inventory.enabled = true;
-                    ev.Target.IsGodModeEnabled = false;
-                    
-                    ev.Target.DisableEffect(EffectType.Ensnared);
-                    ev.Target.DisableEffect(EffectType.Flashed);
-                    ev.Target.DisableEffect(EffectType.Deafened);
-                    ev.Target.DisableEffect(EffectType.AmnesiaItems);
-                    
-                    ev.Target.CurrentItem = item;
-                    if (lift != null)
-                        ev.Target.Teleport(lift.Position + Vector3.up * 2f);
-                    else
-                        ev.Target.Teleport(ev.Target.Position + Vector3.up * 2f);
-                    
-                    ev.Target.Scale = Vector3.one;
-                    ragdoll?.Destroy();
-                });
+            if((bool)(Plugin.Instance.Config.ReholdItems!))
+            {
+                item = ev.Target.CurrentItem;
             }
+            
+            var rand = _rng.NextDouble();
+            _resistances.TryGetValue(ev.Target.NetId, out float tResistance);
+            
+            var effective = ev.Target.IsScp ? rand < ScpChance - tResistance : rand < HumanChance - tResistance;
+            
+            if ((ev.Target.Role == RoleTypeId.Scp173 && !EffectiveOn173) || !effective)
+            { 
+                base.OnShot(ev); 
+                return;
+            }
+
+            var lift = ev.Player.Lift;
+                
+            ev.Target.Scale = Vector3.zero;
+            _resistances[ev.Target.NetId] = tResistance + Resistance;
+            
+            ev.Target.EnableEffect(EffectType.Ensnared, byte.MaxValue);
+            ev.Target.EnableEffect(EffectType.Flashed, byte.MaxValue);
+            ev.Target.EnableEffect(EffectType.Deafened, byte.MaxValue);
+            
+            ev.Target.IsGodModeEnabled = true;
+            Ragdoll? ragdoll = null;
+            
+            if (ev.Target.IsHuman)
+            { ev.Target.CurrentItem = null; ev.Target.Inventory.enabled = false; ev.Target.EnableEffect(EffectType.AmnesiaItems, byte.MaxValue);
+            }
+            else
+            { if (ev.Target.Role != RoleTypeId.Scp106) { ragdoll = Ragdoll.CreateAndSpawn(ev.Target.Role.Type, ev.Target.DisplayNickname, new CustomReasonDamageHandler("Tranquilized."), ev.Target.Position, ev.Target.Rotation, ev.Target); } if (ev.Target.Role == RoleTypeId.Scp096) { var crybaby = (Scp096Role)ev.Target.Role; if (crybaby.RageState is Scp096RageState.Enraged or Scp096RageState.Distressed) { crybaby.RageManager.ServerEndEnrage(); } }
+            }
+            Timing.CallDelayed(5, () =>
+            { ev.Target.Inventory.enabled = true; ev.Target.IsGodModeEnabled = false; ev.Target.DisableEffect(EffectType.Ensnared); ev.Target.DisableEffect(EffectType.Flashed); ev.Target.DisableEffect(EffectType.Deafened); ev.Target.DisableEffect(EffectType.AmnesiaItems); ev.Target.CurrentItem = item; if (lift != null) ev.Target.Teleport(lift.Position + Vector3.up * 2f); else ev.Target.Teleport(ev.Target.Position + Vector3.up * 2f); ev.Target.Scale = Vector3.one; ragdoll?.Destroy();
+            });
             base.OnShot(ev);
         }
 

--- a/Items/Tranquilizer.cs
+++ b/Items/Tranquilizer.cs
@@ -41,7 +41,9 @@ namespace ExtendedItems.Items
         public float Resistance { get; set; } = 0.05f;
 
         [Description("Whether tranquilizer should not effect those with AHP.")]
-        public bool AhpBuff { get; set; } = true;
+        public bool AdrenalineBuff { get; set; } = true;
+        private bool Affected { get; set; } = true;
+
 
         [YamlIgnore] private readonly Random _rng = new();
         [YamlIgnore] private readonly Dictionary<uint, float> _resistances = [];
@@ -76,15 +78,16 @@ namespace ExtendedItems.Items
 
         protected override void OnShot(ShotEventArgs ev)
         {
+            Affected = true;
 
             if (ev.Target == null || Plugin.Instance == null) return;
             if (ev.Target.IsTutorial && !Plugin.Instance.Config.EffectiveOnTutorials) return;
-            
-            if (AhpBuff && ev.Target.ArtificialHealth >= 1) // AHP cancel, buffs anti-cola and blue candy
+
+            foreach (var targetActiveEffect in ev.Target.ActiveEffects)
             {
-                base.OnShot(ev);
-                return;
-            };
+                if (AdrenalineBuff && targetActiveEffect.name == "Invigorated") Affected = false;
+            }
+            if (!Affected) return;
             
             Exiled.API.Features.Items.Item? item = null;
                 


### PR DESCRIPTION
When a player has AHP, the tranquilizer will not affect them. Useful for clutching.

**Idea:** @Gomblim 